### PR TITLE
Add support to set custom logrus instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Logrus logger for gorm v2
 package main
 
 import (
+  "github.com/sirupsen/logrus"
   "gorm.io/gorm"
   "gorm.io/driver/sqlite"
   "github.com/onrik/gorm-logrus"
@@ -12,10 +13,11 @@ import (
 
 func main() {
   db, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{
-    Logger: gorm_logrus.New(),
+    Logger: gorm_logrus.New(logrus.StandardLogger()),
   })
   if err != nil {
     panic("failed to connect database")
   }
 }
 ```
+

--- a/logger.go
+++ b/logger.go
@@ -5,20 +5,22 @@ import (
 	"errors"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 	"gorm.io/gorm/utils"
 )
 
 type logger struct {
+	log                   *logrus.Logger
 	SlowThreshold         time.Duration
 	SourceField           string
 	SkipErrRecordNotFound bool
 }
 
-func New() *logger {
+func New(l *logrus.Logger) *logger {
 	return &logger{
+		log:                   l,
 		SkipErrRecordNotFound: true,
 	}
 }
@@ -28,34 +30,34 @@ func (l *logger) LogMode(gormlogger.LogLevel) gormlogger.Interface {
 }
 
 func (l *logger) Info(ctx context.Context, s string, args ...interface{}) {
-	log.WithContext(ctx).Infof(s, args)
+	l.log.WithContext(ctx).Infof(s, args)
 }
 
 func (l *logger) Warn(ctx context.Context, s string, args ...interface{}) {
-	log.WithContext(ctx).Warnf(s, args)
+	l.log.WithContext(ctx).Warnf(s, args)
 }
 
 func (l *logger) Error(ctx context.Context, s string, args ...interface{}) {
-	log.WithContext(ctx).Errorf(s, args)
+	l.log.WithContext(ctx).Errorf(s, args)
 }
 
 func (l *logger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
 	elapsed := time.Since(begin)
 	sql, _ := fc()
-	fields := log.Fields{}
+	fields := logrus.Fields{}
 	if l.SourceField != "" {
 		fields[l.SourceField] = utils.FileWithLineNum()
 	}
 	if err != nil && !(errors.Is(err, gorm.ErrRecordNotFound) && l.SkipErrRecordNotFound) {
-		fields[log.ErrorKey] = err
-		log.WithContext(ctx).WithFields(fields).Errorf("%s [%s]", sql, elapsed)
+		fields[logrus.ErrorKey] = err
+		l.log.WithContext(ctx).WithFields(fields).Errorf("%s [%s]", sql, elapsed)
 		return
 	}
 
 	if l.SlowThreshold != 0 && elapsed > l.SlowThreshold {
-		log.WithContext(ctx).WithFields(fields).Warnf("%s [%s]", sql, elapsed)
+		l.log.WithContext(ctx).WithFields(fields).Warnf("%s [%s]", sql, elapsed)
 		return
 	}
 
-	log.WithContext(ctx).WithFields(fields).Debugf("%s [%s]", sql, elapsed)
+	l.log.WithContext(ctx).WithFields(fields).Debugf("%s [%s]", sql, elapsed)
 }


### PR DESCRIPTION
It's generally discouraged to use a global instance of e.g. a logger, since it disallows multiple logger instances and configuration and it complicates testing.